### PR TITLE
product: Add AGENTS.md and AI agent usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Using this repo as a reference
+
+This repo is the **SC-OBC Module A1 Product Manual** (Document Number: SC-ESP-00050),
+covering hardware, software, and FPGA documentation for the Space Cubics SC-OBC Module A1,
+an on-board computer for CubeSats of 3U size and larger. If you were pointed at this repo
+to answer engineering questions about that hardware (pinouts, register maps, board layout,
+Zephyr driver usage, etc.), this file is for you. A rendered version is also online at
+https://spacecubics.github.io/sc-docs/, but this checkout is the authoritative full-text
+source, so prefer grepping it directly over fetching the rendered site.
+
+This manual is not something you're expected to edit. If you were actually asked to
+*contribute* to this documentation (fix a typo, add a page, etc.), stop and read
+`README.adoc` and the repo's existing conventions instead. The guidance below is about
+consuming the content, not writing it.
+
+## How the content is organized
+
+Pages are AsciiDoc (`.adoc`), built with Antora. The manual is split across three
+top-level directories by subject, and each of those has separate `en/` and `ja/`
+language trees with the same structure:
+
+- `product/<lang>/modules/`: Product Overview and OBC Module hardware specs (`ROOT/`),
+  Development Board (`dev-board/`)
+- `software/<lang>/modules/`: Zephyr-based software, setup, samples, driver usage
+  (`software/`)
+- `fpga/<lang>/modules/`: FPGA documentation (`fpga/`)
+
+Default to the `en/` trees unless you were told to answer in Japanese or the user's
+question was in Japanese. Within each module: `nav.adoc` lists that section's pages in
+reading order (check this first to see what exists before grepping blind), and
+`pages/*.adoc` holds the actual content. Diagrams/images live under each module's
+`assets/images/`.
+
+## Reading AsciiDoc conventions
+
+- `xref:page.adoc[Text]` is an internal cross-reference (a link), not something to modify.
+- `include::file.adoc[]` pulls another file's content in at build time. If a page looks
+  sparse, check for an `include::` pulling in the real content.
+- Attributes (`{like-this}`) are variables defined in `antora.yml` or the page itself.
+
+## Finding things fast
+
+Prefer `grep -ri` over reading the whole tree. Search for register names, signal names,
+part numbers, or connector labels directly. Hardware specs and interface tables are the
+densest source of the kind of detail firmware/integration work usually needs
+(`product/en/modules/ROOT/pages/`, `product/en/modules/dev-board/pages/interface-specs.adoc`).
+For software/driver questions, `software/en/modules/software/pages/use-zephyr-drivers/`
+and `develop-zephyr-app/` have worked examples.

--- a/product/en/modules/ROOT/nav.adoc
+++ b/product/en/modules/ROOT/nav.adoc
@@ -1,5 +1,6 @@
 .Product Overview
 * xref:introduction.adoc[]
+* xref:using-ai-agents.adoc[]
 * xref:precautions.adoc[]
 * xref:terms.adoc[]
 * xref:block-diagram.adoc[]

--- a/product/en/modules/ROOT/pages/using-ai-agents.adoc
+++ b/product/en/modules/ROOT/pages/using-ai-agents.adoc
@@ -1,0 +1,26 @@
+= Using This Manual With an AI Agent
+
+This manual is written to be used directly by AI coding agents (Claude Code, Codex, Cursor,
+GitHub Copilot, and similar tools), not only read by humans. Whether you are laying out a carrier board around
+the SC-OBC Module A1, developing FPGA logic for your CubeSat, or writing Zephyr RTOS
+software, you can clone the manual's source repository and point your agent at it instead
+of searching the rendered site by hand.
+
+[source, console]
+----
+git clone https://github.com/spacecubics/sc-docs-a1
+----
+
+The repository includes an `AGENTS.md` file that tells the agent how the manual is
+organized and where to look for hardware specs, interface tables, or software examples.
+You do not need to tell the agent which section is relevant. Just ask your question, for
+example:
+
+* "What is the maximum voltage on connector J3?"
+* "What does the TRCH do before the FPGA starts, versus after?"
+* "How do I add a GPIO driver under Zephyr?"
+
+and the agent will find the right page on its own.
+
+For a browsable version of the same content, see the published manual at
+https://docs.spacecubics.com/[docs.spacecubics.com].


### PR DESCRIPTION
Customers building carrier boards, FPGA logic, or software against this hardware increasingly use AI coding agents to work through the manual. Without repo-level guidance, an agent has no way to know how the manual is organized and has to search blindly.

AGENTS.md orients any agent that clones the repo: what the manual covers, how content is split across modules, and where to find specs, interface tables, and examples. The new product-overview page tells human readers that this workflow is available and how to use it.

This AGENTS.md is scoped to consumers of the manual only. It is not guidance for writing or contributing to the manual itself, and Space Cubics engineers should not assume it covers that. If we need agent guidance for authoring the docs, add it separately (do not fold contributor instructions into this file); the two audiences need different information and mixing them would confuse whichever agent reads it.

Assisted-by: Claude Code:claude-sonnet-5