### PR TITLE
ci: Skip workflow deployment in forks

### DIFF
--- a/.github/workflows/dispatch-docs-build.yml
+++ b/.github/workflows/dispatch-docs-build.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   dispatch:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 


### PR DESCRIPTION
Restrict the deployment job to the upstream repository owner.

This prevents the workflow from attempting to deploy in forks, where the required GitHub Secret configuration may not be available.